### PR TITLE
[33기 팀 wantUS] 소셜 로그인 기능 구현 (CREATE: wantUS SignIn View)

### DIFF
--- a/core/utils.py
+++ b/core/utils.py
@@ -4,14 +4,11 @@ from django.conf import settings
 
 from users.models    import User
 
-
-
-def access_token_check(func):
+def signin_decorator(func):
     def wrapper(self,request,*args,**kwargs):
         try:
             access_token = request.headers.get('Authorization')
             payload      = jwt.decode(access_token, settings.SECRET_KEY, algorithms=settings.ALGORITHM)
-            
             request.user = User.objects.get(id = payload['id'])
 
             return func(self,request,*args,**kwargs)

--- a/users/tests.py
+++ b/users/tests.py
@@ -1,3 +1,182 @@
-from django.test import TestCase
+import jwt
 
-# Create your tests here.
+from django.test import TestCase, Client
+from django.conf import settings
+from unittest import mock
+from unittest.mock import patch
+
+from users.models import *
+
+class KakaoSignInTest(TestCase):
+    def setUp(self):
+        Social.objects.create(
+            id   = 2,
+            name = 'kakao'
+        )
+        User.objects.create(
+            id                = 1,
+            name              = '김아무개',
+            profile_image     = 'http://k.kakaocdn.net/dn/eeTOt3/btrtLULVtEZ/5EXNjngEhg1QeAgUE3KKAk/img_640x640.jpg',
+            email             = 'kim1234@gmail.com',
+            social_account_id = '12345678',
+            terms_agreements  = {1:2},
+            social_id         = Social.objects.get(name="kakao").id,
+        )
+
+    def tearDown(self):
+        User.objects.all().delete()
+
+    @patch("users.views.requests")
+    def test_success_kakao_new_user(self, mocked_requests):
+        client = Client()
+
+        class MockedResponse:
+            def json(self): 
+                return {
+                    "id"          : 12341234,
+                    "connected_at": "2022-06-08T01:29:52Z",
+                    "properties"  : {
+                        "nickname"       : "홍길동",
+                        "profile_image"  : "http://k.kakaocdn.net/dn/eeTOt3/btrtLULVtEZ/5EXNjngEhg1QeAgUE3KKAk/img_640x640.jpg",
+                        "thumbnail_image": "http://k.kakaocdn.net/dn/eeTOt3/btrtLULVtEZ/5EXNjngEhg1QeAgUE3KKAk/img_110x110.jpg"
+                    },
+                    "kakao_account": {
+                        "profile_nickname_needs_agreement": False,
+                        "profile_image_needs_agreement"   : False,
+                        "profile"                         : {
+                            "nickname"           : "홍길동",
+                            "thumbnail_image_url": "http://k.kakaocdn.net/dn/eeTOt3/btrtLULVtEZ/5EXNjngEhg1QeAgUE3KKAk/img_110x110.jpg",
+                            "profile_image_url"  : "http://k.kakaocdn.net/dn/eeTOt3/btrtLULVtEZ/5EXNjngEhg1QeAgUE3KKAk/img_640x640.jpg",
+                            "is_default_image"   : False
+                            },
+                        "has_email"            : True,
+                        "email_needs_agreement": False,
+                        "is_email_valid"       : True,
+                        "is_email_verified"    : True,
+                        "email"                : "hong123@gmail.com"
+                    }
+                }
+
+        mocked_requests.get = mock.MagicMock(return_value = MockedResponse())
+        headers             = {"HTTP_Authorization" : "12341234"}
+        response            = client.get("/user/signin/kakao/callback", **headers)
+
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.json(), {
+            'message': 'ACCOUNT CREATED',
+            'token'  : jwt.encode({'id': User.objects.latest('id').id}, settings.SECRET_KEY, algorithm=settings.ALGORITHM)
+        })        
+
+    @patch("users.views.requests")
+    def test_success_kakao_existed_user(self, mocked_requests):
+        client = Client()
+
+        class MockedResponse:
+            def json(self):
+                return {
+                    "id"          : 12345678,
+                    "connected_at": "2022-06-08T01:29:52Z",
+                    "properties"  : {
+                        "nickname"       : "김아무개",
+                        "profile_image"  : "http://k.kakaocdn.net/dn/eeTOt3/btrtLULVtEZ/5EXNjngEhg1QeAgUE3KKAk/img_640x640.jpg",
+                        "thumbnail_image": "http://k.kakaocdn.net/dn/eeTOt3/btrtLULVtEZ/5EXNjngEhg1QeAgUE3KKAk/img_110x110.jpg"
+                    },
+                    "kakao_account": {
+                        "profile_nickname_needs_agreement": False,
+                        "profile_image_needs_agreement"   : False,
+                        "profile"                         : {
+                            "nickname"           : "김아무개",
+                            "thumbnail_image_url": "http://k.kakaocdn.net/dn/eeTOt3/btrtLULVtEZ/5EXNjngEhg1QeAgUE3KKAk/img_110x110.jpg",
+                            "profile_image_url"  : "http://k.kakaocdn.net/dn/eeTOt3/btrtLULVtEZ/5EXNjngEhg1QeAgUE3KKAk/img_640x640.jpg",
+                            "is_default_image"   : False
+                            },
+                        "has_email"            : True,
+                        "email_needs_agreement": False,
+                        "is_email_valid"       : True,
+                        "is_email_verified"    : True,
+                        "email"                : "Kim1234@gmail.com"
+                    }
+                }
+
+        mocked_requests.get = mock.MagicMock(return_value = MockedResponse())
+        headers             = {"HTTP_Authorization" : "12345678"}
+        response            = client.get("/user/signin/kakao/callback", **headers)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {
+            'message': 'SIGN IN SUCCESS',
+            'token'  : jwt.encode({'id': User.objects.latest('id').id}, settings.SECRET_KEY, algorithm=settings.ALGORITHM)
+        })
+
+class GoogleSignInTest(TestCase):
+    def setUp(self): 
+        Social.objects.create(
+            id   = 1,
+            name = 'google'
+        )
+        User.objects.create(
+            id                = 1,
+            name              = '황재승',
+            profile_image     = 'https://lh3.googleusercontent.com/a/AATXAJyJ31Yj38kTInJgJ4ducCl6Wx-QlX49FzQh0kF9=s96-c',
+            email             = 'gogolee@gmail.com',
+            social_account_id = '5544332211',
+            terms_agreements  = {1:2},
+            social_id         = Social.objects.get(name="google").id,
+        )
+
+    def tearDown(self):
+        User.objects.all().delete()
+
+    @patch("users.views.requests")
+    def test_success_google_new_user(self, mocked_requests):
+        client = Client()
+
+        class MockedResponse:
+            def json(self):
+                return {
+                    "sub"           : "1122334455",
+                    "name"          : "\ud669\uc7ac\uc2b9",
+                    "given_name"    : "\uc7ac\uc2b9",
+                    "family_name"   : "\ud669",
+                    "picture"       : "https://lh3.googleusercontent.com/a/AFFEASSSXXDFAEucCl6Wx-QlX49FzQh0kF9=s96-c",
+                    "email"         : "lululala@gmail.com",
+                    "email_verified": True,
+                    "locale"        : "ko"
+                    }
+
+        mocked_requests.get = mock.MagicMock(return_value = MockedResponse())
+        headers             = {"HTTP_Authorization" : "11223344"}
+        response            = client.get("/user/signin/google/callback", **headers)
+
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.json(), {
+            'message': 'ACCOUNT CREATED',
+            'token'  : jwt.encode({'id': User.objects.latest('id').id}, settings.SECRET_KEY, algorithm=settings.ALGORITHM)
+        })     
+
+    @patch("users.views.requests")
+    def test_success_kakao_existed_user(self, mocked_requests):
+        client = Client()
+
+        class MockedResponse:
+            def json(self):
+                return {
+                    "sub"           : "5544332211",
+                    "name"          : "\ud669\uc7ac\uc2b9",
+                    "given_name"    : "\uc7ac\uc2b9",
+                    "family_name"   : "\ud669",
+                    "picture"       : "https://lh3.googleusercontent.com/a/AATXAJyJ31Yj38kTInJgJ4ducCl6Wx-QlX49FzQh0kF9=s96-c",
+                    "email"         : "gogolee@gmail.com",
+                    "email_verified": True,
+                    "locale"        : "ko"
+                    }
+
+        mocked_requests.get = mock.MagicMock(return_value = MockedResponse())
+        headers = {"HTTP_Authorization" : "12345678"}
+        response = client.get("/user/signin/google/callback", **headers)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {
+            'message': 'SIGN IN SUCCESS', 
+            'token': jwt.encode({'id': User.objects.latest('id').id}, settings.SECRET_KEY, algorithm=settings.ALGORITHM)
+        })

--- a/users/urls.py
+++ b/users/urls.py
@@ -1,0 +1,9 @@
+from django.urls import path 
+from users.views import KakaoSignInView, KakaoCallBackView, GoogleSignInView, GoogleCallBackView
+
+urlpatterns = [
+    path("/signin/kakao/callback", KakaoCallBackView.as_view()),
+    path("/signin/kakao", KakaoSignInView.as_view()),
+    path("/signin/google", GoogleSignInView.as_view()),
+    path("/signin/google/callback", GoogleCallBackView.as_view()),
+]

--- a/users/views.py
+++ b/users/views.py
@@ -1,3 +1,110 @@
-from django.shortcuts import render
+import json
+import jwt
+import requests
 
-# Create your views here.
+from django.shortcuts import redirect
+from django.views import View
+from django.http import JsonResponse
+from django.conf import settings
+
+from users.models import User,Social
+
+class KakaoSignInView(View):
+    def get(self, request):
+        client_id     = settings.KAKAO_CLIENT_ID
+        kakao_auth_id = "https://kauth.kakao.com/oauth/authorize?response_type=code"
+        redirect_uri  = "http://localhost:8000/user/signin/kakao/callback"
+
+        return redirect(
+            f"{kakao_auth_id}&client_id={client_id}&redirect_uri={redirect_uri}"
+            )
+
+class KakaoCallBackView(View):
+    def get(self, request):
+        kakao_token_api = "https://kauth.kakao.com/oauth/token"
+        data = {
+            "grant_type"  : "authorization_code",
+            "client_id"   : settings.KAKAO_CLIENT_ID,
+            "redirect_uri": "http://localhost:8000/user/signin/kakao/callback",
+            "code"        : request.GET.get("code")
+        }
+
+        access_token = requests.post(kakao_token_api, data=data).json().get('access_token')
+        user_info    = requests.get('https://kapi.kakao.com/v2/user/me', headers={"Authorization": f"Bearer {access_token}"}).json()
+
+        kakao_id          = user_info["id"]
+        kakao_name        = user_info["properties"]["nickname"]
+        kakao_email       = user_info["kakao_account"]["email"]
+        profile_image_url = user_info["properties"]["profile_image"]
+
+        if User.objects.filter(social_account_id = kakao_id).exists():
+            user = User.objects.get(social_account_id = kakao_id)
+            access_token = jwt.encode({"id" : user.id}, settings.SECRET_KEY, algorithm = settings.ALGORITHM)
+
+            return JsonResponse({"message" : "SIGN IN SUCCESS", "token" : access_token}, status=200)
+        
+        User(
+            social_account_id = kakao_id,
+            name              = kakao_name,
+            email             = kakao_email,
+            profile_image     = profile_image_url,
+            social_id         = Social.objects.get(name="kakao").id,
+            terms_agreements  = {1:2},
+        ).save()
+
+        user = User.objects.get(social_account_id=kakao_id)
+        access_token = jwt.encode({"id" : user.id}, settings.SECRET_KEY, algorithm = settings.ALGORITHM)
+        
+        return JsonResponse({"message" : "ACCOUNT CREATED", "token" : access_token}, status=201)
+
+class GoogleSignInView(View):
+    def get(self, request):
+        client_id       = settings.GOOGLE_CLIENT_ID
+        redirect_uri    = "http://localhost:8000/user/signin/google/callback"
+        scope           = "https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/userinfo.profile"
+        google_auth_api = "https://accounts.google.com/o/oauth2/v2/auth"
+
+        return redirect(
+            f"{google_auth_api}?scope={scope}&response_type=code&redirect_uri={redirect_uri}&client_id={client_id}"
+        )
+
+class GoogleCallBackView(View):
+    def get(self, request):
+        google_token_api = "https://oauth2.googleapis.com/token"
+        data = {
+            "code" : request.GET.get("code"),
+            "client_id" : settings.GOOGLE_CLIENT_ID,
+            "client_secret" : settings.GOOGLE_CLIENT_SECRET,
+            "redirect_uri" : "http://localhost:8000/user/signin/google/callback",
+            "grant_type" : "authorization_code"
+        }
+
+        access_token = requests.post(google_token_api, data=data).json()['access_token']
+        req_uri      = 'https://www.googleapis.com/oauth2/v3/userinfo'
+        headers      = {'Authorization': f'Bearer {access_token}'}
+
+        user_info        = requests.get(req_uri, headers=headers).json()
+        google_id        = user_info["sub"]
+        google_name      = user_info["name"]
+        google_email     = user_info["email"]
+        google_image_url = user_info["picture"]
+
+        if User.objects.filter(social_account_id = google_id).exists():
+            user         = User.objects.get(social_account_id = google_id)
+            access_token = jwt.encode({"id" : user.id}, settings.SECRET_KEY, algorithm = settings.ALGORITHM)
+
+            return JsonResponse({"message" : "SIGN IN SUCCESS", "token" : access_token}, status=200)
+        
+        User(
+            social_account_id = google_id,
+            name              = google_name,
+            email             = google_email,
+            profile_image     = google_image_url,
+            social_id         = Social.objects.get(name="google").id,
+            terms_agreements  = {1:2},
+        ).save()
+
+        user         = User.objects.get(social_account_id=google_id)
+        access_token = jwt.encode({"id" : user.id}, settings.SECRET_KEY, algorithm = settings.ALGORITHM)
+        
+        return JsonResponse({"message" : "ACCOUNT CREATED", "token" : access_token}, status=201)

--- a/wantus/settings.py
+++ b/wantus/settings.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from my_settings import SECRET_KEY, DATABASES, ALGORITHM
+from my_settings import GOOGLE_CLIENT_SECRET, GOOGLE_CLIENT_ID, KAKAO_CLIENT_ID, SECRET_KEY, DATABASES, ALGORITHM
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -15,7 +15,6 @@ SECRET_KEY = SECRET_KEY
 DEBUG = True
 
 ALLOWED_HOSTS = ['*']
-
 
 # Application definition
 
@@ -147,3 +146,25 @@ CORS_ALLOW_HEADERS = (
 )
 
 ALGORITHM = ALGORITHM
+
+LOGGING = {
+    'disable_existing_loggers': False,
+    'version': 1,
+    'handlers': {
+        'console': {
+            'class': 'logging.StreamHandler',
+            'level': 'DEBUG',
+        },
+    },
+    'loggers': {
+        'django.db.backends': {
+            'handlers': ['console'],
+            'level': 'DEBUG',
+            'propagate': False,
+        },
+    },
+}
+
+KAKAO_CLIENT_ID      = KAKAO_CLIENT_ID
+GOOGLE_CLIENT_ID     = GOOGLE_CLIENT_ID
+GOOGLE_CLIENT_SECRET = GOOGLE_CLIENT_SECRET

--- a/wantus/urls.py
+++ b/wantus/urls.py
@@ -1,5 +1,5 @@
-from django.urls import path
+from django.urls import path, include
 
 urlpatterns = [
-
+    path('user', include("users.urls")),
 ]


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 소셜 로그인(카카오, 구글) 기능 구현

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
### 1. 소셜 로그인 기능 구현 완료
 - 인가 코드 받기
 - 카카오 토큰 받기
 - 사용자 정보 가져오기
 - 받아온 사용자 정보 DB에 저장
 - 내 토큰 발급
 - 소셜 아이디(Social_account_id)가 이미 DB에 존재하는 경우 로그인이 되며, 토큰만 발급될 수 있도록 함
 - 카카오, 구글 로그인 구현

### 2. tests.py
- 새로운 계정으로 진행하는 경우 : "test_success_(social)_new_user" ➤ 200 반환
- 존재하는 계정으로 진행하는 경우 : "test_success_(social)_existed_user" ➤ 201 반환 

<img width="569" alt="image" src="https://user-images.githubusercontent.com/75832544/172990805-56608991-18f1-4e4f-8968-e5d9ccab5a7f.png">


<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- Unittest를 사용 해봤고 전체적인 흐름에 대해서는 이해했으나, 세부적인 내용에 대해서는 아직 공부가 필요하며, 어떤 세부적인 내용을 더 공부해야하는 지를 파악할 수 있는 시간이 필요할듯 합니다. 추가적으로 연습해보겠습니다.

<br />

## :: 기타 질문 및 특이 사항
- 현재까지는 없음.
