### PR TITLE
[33기 팀 wantUS] 팔로우한 채용공고 리스트 페이지 (CREATE: followed Job View)

### DIFF
--- a/jobs/tests.py
+++ b/jobs/tests.py
@@ -170,3 +170,77 @@ class FollowTest(TestCase):
             "results"     : False,
             "follow_count": 0
         })
+
+class FollowedJobTest(TestCase):
+    def setUp(self):
+        Social.objects.create(
+            id   = 2,
+            name = 'kakao'
+        )
+        User.objects.create(
+            id                = 1,
+            name              = '김아무개',
+            profile_image     = 'http://k.kakaocdn.net/dn/eeTOt3/btrtLULVtEZ/5EXNjngEhg1QeAgUE3KKAk/img_640x640.jpg',
+            email             = 'kim1234@gmail.com',
+            social_account_id = '12345678',
+            social_id         = Social.objects.get(name="kakao").id,
+        )
+        Location.objects.create(
+            id   = 1,
+            name = "서울"
+        )
+        Company.objects.create(
+            id          = 1,
+            name        = "위코드",
+            address     = "서울시 송파구 오륜동",
+            logo        = "https://i.pinimg.com/564x/f6/16/1d/f6161d61d9223223fcad406a632fa828.jpg",
+            location_id = 1,
+            latitude    = "37.1234",
+            longitude   = "123.1234"
+        )
+        MainCategory.objects.create(
+            id   = 1,
+            name = "개발"
+        )
+        SubCategory.objects.create(
+            id               = 1,
+            name             = "앱 개발자",
+            main_category_id = 1,
+        )
+        Career.objects.create(
+            id   = 1,
+            name = "신입",
+        )
+        Job.objects.create(
+            id              = 1,
+            name            = "위코드 개발자",
+            content         = "내용",
+            due_date        = "2022-06-30",
+            career_id       = 1,
+            company_id      = 1,
+            sub_category_id = 1
+        )
+        CompanyImage.objects.create(
+            id = 1,
+            image_url = "https://i.pinimg.com/564x/27/e0/74/27e074008b1d54fb474224de9102651b.jpg",
+            company_id_id = 1
+        )
+        self.token = jwt.encode({"id" : User.objects.get(id=1).id}, settings.SECRET_KEY, algorithm = settings.ALGORITHM)
+
+    def tearDown(self):
+        User.objects.all().delete()
+        Social.objects.all().delete()
+        Location.objects.all().delete()
+        Company.objects.all().delete()
+        MainCategory.objects.all().delete()
+        SubCategory.objects.all().delete()
+        Career.objects.all().delete()
+        Job.objects.all().delete()
+        CompanyImage.objects.all().delete()
+
+    def test_followed_job_success(self):
+        client   = Client()
+        headers  = {"HTTP_Authorization" : self.token}
+        response = client.get("/job/followedjob", **headers, content_type='application/json')
+
+        self.assertEqual(response.status_code, 200)

--- a/jobs/urls.py
+++ b/jobs/urls.py
@@ -1,7 +1,8 @@
 from django.urls import path
-from jobs.views  import JobDetailView, FollowView
+from jobs.views  import JobDetailView, FollowView, FollowedJobView
 
 urlpatterns = [
     path("/<int:job_id>", JobDetailView.as_view()),
     path("/<int:job_id>/follow", FollowView.as_view()),
+    path("/followedjob", FollowedJobView.as_view())
 ] 

--- a/jobs/views.py
+++ b/jobs/views.py
@@ -60,3 +60,17 @@ class FollowView(View):
         
         follow_count = Follow.objects.filter(job_id=job_id).count()
         return JsonResponse({"message" : message, "results" : results, "follow_count" : follow_count}, status =200)
+
+class FollowedJobView(View):
+    @signin_decorator
+    def get(self, request):
+        user = request.user
+        follows = Follow.objects.select_related('job', 'job__company', 'job__company__location').filter(user_id = user.id)
+        followed_jobs = [{
+            'position' : follow.job.name,
+            'company_name' : follow.job.company.name,
+            'location' : follow.job.company.location.name,
+            'image' : follow.job.company.companyimage_set.first().image_url
+        } for follow in follows]
+
+        return JsonResponse({"results" : followed_jobs}, status=200)


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [x] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 로그인한 유저가 팔로우한 채용공고 리스트 출력 페이지 구현

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 로그인데코레이터를 통한 유저 데이터를 기반으로 해당 유저가 팔로우한 채용공고 리스트 데이터 출력
- select_related() ORM 최적화 완료
- 프론트엔드와 통신 확인 완료
- Code convention 체크
- unittest 확인 완료

<img width="570" alt="스크린샷 2022-06-15 오전 11 20 28" src="https://user-images.githubusercontent.com/75832544/173738715-2798341c-6e41-4b0e-b5ed-7ca4d34c304c.png">


<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- None.

<br />

## :: 기타 질문 및 특이 사항
- None.
